### PR TITLE
[KUITEE - 10] feat : 회원가입

### DIFF
--- a/src/main/java/com/kuit/kupage/common/advice/KupageControllerAdvice.java
+++ b/src/main/java/com/kuit/kupage/common/advice/KupageControllerAdvice.java
@@ -1,0 +1,16 @@
+package com.kuit.kupage.common.advice;
+
+import com.kuit.kupage.exception.KupageException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class KupageControllerAdvice {
+
+    @ExceptionHandler(KupageException.class)
+    public ResponseEntity<Object> handleException(KupageException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/kuit/kupage/common/auth/AuthMember.java
+++ b/src/main/java/com/kuit/kupage/common/auth/AuthMember.java
@@ -1,0 +1,37 @@
+package com.kuit.kupage.common.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class AuthMember implements UserDetails {
+
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final List<GrantedAuthority> authorities;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+}

--- a/src/main/java/com/kuit/kupage/domain/detail/Detail.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/Detail.java
@@ -17,7 +17,7 @@ public class Detail {
     private Long id;
 
     private String name;
-    private Long studentNumber;
+    private String studentNumber;
     private String departName;
 
     @Enumerated(EnumType.STRING)
@@ -27,7 +27,7 @@ public class Detail {
     private String phoneNumber;
     private LocalDate birthday;
 
-    public static Detail of(String name, Long studentNumber, String departName, Grade grade, String githubId, String email, String phoneNumber, LocalDate birthday) {
+    public static Detail of(String name, String studentNumber, String departName, Grade grade, String githubId, String email, String phoneNumber, LocalDate birthday) {
         Detail detail = new Detail();
         detail.name = name;
         detail.studentNumber = studentNumber;

--- a/src/main/java/com/kuit/kupage/domain/detail/Detail.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/Detail.java
@@ -17,12 +17,27 @@ public class Detail {
     private Long id;
 
     private String name;
-    private String studentNumber;
+    private Long studentNumber;
     private String departName;
-    private String grade;
+
+    @Enumerated(EnumType.STRING)
+    private Grade grade;
     private String githubId;
     private String email;
     private String phoneNumber;
     private LocalDate birthday;
+
+    public static Detail of(String name, Long studentNumber, String departName, Grade grade, String githubId, String email, String phoneNumber, LocalDate birthday) {
+        Detail detail = new Detail();
+        detail.name = name;
+        detail.studentNumber = studentNumber;
+        detail.departName = departName;
+        detail.grade = grade;
+        detail.githubId = githubId;
+        detail.email = email;
+        detail.phoneNumber = phoneNumber;
+        detail.birthday = birthday;
+        return detail;
+    }
 
 }

--- a/src/main/java/com/kuit/kupage/domain/detail/Detail.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/Detail.java
@@ -1,0 +1,28 @@
+package com.kuit.kupage.domain.detail;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Detail {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "detail_id")
+    private Long id;
+
+    private String name;
+    private String studentNumber;
+    private String departName;
+    private String grade;
+    private String githubId;
+    private String email;
+    private String phoneNumber;
+    private LocalDate birthday;
+
+}

--- a/src/main/java/com/kuit/kupage/domain/detail/Detail.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/Detail.java
@@ -1,14 +1,14 @@
 package com.kuit.kupage.domain.detail;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Detail {
 
@@ -28,15 +28,17 @@ public class Detail {
     private LocalDate birthday;
 
     public static Detail of(String name, String studentNumber, String departName, Grade grade, String githubId, String email, String phoneNumber, LocalDate birthday) {
-        Detail detail = new Detail();
-        detail.name = name;
-        detail.studentNumber = studentNumber;
-        detail.departName = departName;
-        detail.grade = grade;
-        detail.githubId = githubId;
-        detail.email = email;
-        detail.phoneNumber = phoneNumber;
-        detail.birthday = birthday;
+        Detail detail = Detail.builder()
+                .name(name)
+                .studentNumber(studentNumber)
+                .departName(departName)
+                .grade(grade)
+                .githubId(githubId)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .birthday(birthday)
+                .build();
+
         return detail;
     }
 

--- a/src/main/java/com/kuit/kupage/domain/detail/Grade.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/Grade.java
@@ -1,0 +1,21 @@
+package com.kuit.kupage.domain.detail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum Grade {
+    FIRST_YEAR("1학년"),
+    SECOND_YEAR("2학년"),
+    THIRD_YEAR("3학년"),
+    FOURTH_YEAR("4학년"),
+    FIFTH_YEAR("5학년"),
+    SIXTH_YEAR("6학년"),
+    LEAVE_OF_ABSENCE("휴학"),
+    EXTENDED_SEMESTER("초과학기"),
+    GRADUATED("졸업"),
+    GRADUATION_DEFERRED("졸업 유예");
+
+    private final String description;
+}

--- a/src/main/java/com/kuit/kupage/domain/detail/controller/DetailAuthController.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/controller/DetailAuthController.java
@@ -1,0 +1,32 @@
+package com.kuit.kupage.domain.detail.controller;
+
+import com.kuit.kupage.common.auth.AuthMember;
+import com.kuit.kupage.common.auth.AuthTokenResponse;
+import com.kuit.kupage.domain.detail.dto.SignupRequest;
+import com.kuit.kupage.domain.detail.service.DetailService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class DetailAuthController {
+
+    private final DetailService detailService;
+
+    @PostMapping("signup")
+    public ResponseEntity<AuthTokenResponse> signup(@Valid @RequestBody SignupRequest signupRequest,
+                                                    @AuthenticationPrincipal AuthMember authMember) {
+
+        AuthTokenResponse response = detailService.signup(signupRequest, authMember.getId());
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/kuit/kupage/domain/detail/dto/SignupRequest.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/dto/SignupRequest.java
@@ -3,29 +3,17 @@ package com.kuit.kupage.domain.detail.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kuit.kupage.domain.detail.Grade;
 import jakarta.validation.constraints.*;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDate;
 
-@Getter
-@Setter
-public class SignupRequest {
-    @Size(min = 2)
-    private String name;
-    @NotBlank
-    private String studentNumber;
-    @NotNull
-    private Grade grade;
-    @NotBlank
-    private String college;
-    @NotBlank
-    private String departName;
-    private String githubId;
-    @Email
-    private String email;
-    @Pattern(regexp = "010-\\d{4}-\\d{4}")
-    private String phoneNumber;
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDate birthday;
+public record SignupRequest(
+        @Size(min = 2) String name,
+        @NotBlank String studentNumber,
+        @NotNull Grade grade,
+        @NotBlank String college,
+        @NotBlank String departName,
+        String githubId,
+        @Email String email,
+        @Pattern(regexp = "010-\\d{4}-\\d{4}") String phoneNumber,
+        @JsonFormat(pattern = "yyyy-MM-dd") LocalDate birthday) {
 }

--- a/src/main/java/com/kuit/kupage/domain/detail/dto/SignupRequest.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/dto/SignupRequest.java
@@ -13,8 +13,8 @@ import java.time.LocalDate;
 public class SignupRequest {
     @Size(min = 2)
     private String name;
-    @NotNull
-    private Long studentNumber;
+    @NotBlank
+    private String studentNumber;
     @NotNull
     private Grade grade;
     @NotBlank

--- a/src/main/java/com/kuit/kupage/domain/detail/dto/SignupRequest.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/dto/SignupRequest.java
@@ -1,0 +1,31 @@
+package com.kuit.kupage.domain.detail.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.kuit.kupage.domain.detail.Grade;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class SignupRequest {
+    @Size(min = 2)
+    private String name;
+    @NotNull
+    private Long studentNumber;
+    @NotNull
+    private Grade grade;
+    @NotBlank
+    private String college;
+    @NotBlank
+    private String departName;
+    private String githubId;
+    @Email
+    private String email;
+    @Pattern(regexp = "010-\\d{4}-\\d{4}")
+    private String phoneNumber;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birthday;
+}

--- a/src/main/java/com/kuit/kupage/domain/detail/repository/DetailRepository.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/repository/DetailRepository.java
@@ -1,0 +1,7 @@
+package com.kuit.kupage.domain.detail.repository;
+
+import com.kuit.kupage.domain.detail.Detail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DetailRepository extends JpaRepository<Detail, Long> {
+}

--- a/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
@@ -1,0 +1,46 @@
+package com.kuit.kupage.domain.detail.service;
+
+import com.kuit.kupage.common.auth.AuthTokenResponse;
+import com.kuit.kupage.common.auth.JwtTokenService;
+import com.kuit.kupage.domain.detail.Detail;
+import com.kuit.kupage.domain.detail.dto.SignupRequest;
+import com.kuit.kupage.domain.detail.repository.DetailRepository;
+import com.kuit.kupage.domain.member.Member;
+import com.kuit.kupage.domain.member.repository.MemberRepository;
+import com.kuit.kupage.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DetailService {
+
+    private final MemberRepository memberRepository;
+    private final DetailRepository detailRepository;
+    private final JwtTokenService jwtTokenService;
+
+    @Transactional
+    public AuthTokenResponse signup(SignupRequest signupRequest, Long memberId) {
+
+        //todo 예외 처리 어캐할지?
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException("존재하지 않는 회원입니다."));
+
+        Detail savedDetail = detailRepository.save(Detail.of(signupRequest.getName(),
+                signupRequest.getStudentNumber(),
+                signupRequest.getDepartName(),
+                signupRequest.getGrade(),
+                signupRequest.getGithubId(),
+                signupRequest.getEmail(),
+                signupRequest.getPhoneNumber(),
+                signupRequest.getBirthday()));
+
+        member.setAssociationDetail(savedDetail);
+
+        AuthTokenResponse authTokenResponse = jwtTokenService.generateTokens(memberId);
+
+        return authTokenResponse;
+    }
+}

--- a/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
@@ -28,7 +28,7 @@ public class DetailService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException("존재하지 않는 회원입니다."));
 
-        if (member.getDetail() == null) {
+        if (member.getDetail() != null) {
             throw new MemberException("이미 회원가입 된 멤버입니다.");
         }
 

--- a/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
@@ -32,14 +32,14 @@ public class DetailService {
             throw new MemberException("이미 회원가입 된 멤버입니다.");
         }
 
-        Detail savedDetail = detailRepository.save(Detail.of(signupRequest.getName(),
-                signupRequest.getStudentNumber(),
-                signupRequest.getDepartName(),
-                signupRequest.getGrade(),
-                signupRequest.getGithubId(),
-                signupRequest.getEmail(),
-                signupRequest.getPhoneNumber(),
-                signupRequest.getBirthday()));
+        Detail savedDetail = detailRepository.save(Detail.of(signupRequest.name(),
+                signupRequest.studentNumber(),
+                signupRequest.departName(),
+                signupRequest.grade(),
+                signupRequest.githubId(),
+                signupRequest.email(),
+                signupRequest.phoneNumber(),
+                signupRequest.birthday()));
 
         member.setAssociationDetail(savedDetail);
 

--- a/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
@@ -28,6 +28,10 @@ public class DetailService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException("존재하지 않는 회원입니다."));
 
+        if (member.getDetail() == null) {
+            throw new MemberException("이미 회원가입 된 멤버입니다.");
+        }
+
         Detail savedDetail = detailRepository.save(Detail.of(signupRequest.getName(),
                 signupRequest.getStudentNumber(),
                 signupRequest.getDepartName(),

--- a/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/service/DetailService.java
@@ -41,7 +41,7 @@ public class DetailService {
                 signupRequest.phoneNumber(),
                 signupRequest.birthday()));
 
-        member.setAssociationDetail(savedDetail);
+        member.updateDetail(savedDetail);
 
         AuthTokenResponse authTokenResponse = jwtTokenService.generateTokens(memberId);
 

--- a/src/main/java/com/kuit/kupage/domain/member/Member.java
+++ b/src/main/java/com/kuit/kupage/domain/member/Member.java
@@ -1,6 +1,7 @@
 package com.kuit.kupage.domain.member;
 
 import com.kuit.kupage.common.auth.AuthTokenResponse;
+import com.kuit.kupage.domain.detail.Detail;
 import com.kuit.kupage.domain.oauth.dto.DiscordInfoResponse;
 import com.kuit.kupage.domain.oauth.dto.DiscordTokenResponse;
 import jakarta.persistence.*;
@@ -36,6 +37,10 @@ public class Member {
     @Embedded
     private DiscordToken discordToken;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "detail_id")
+    private Detail detail;
+
     public Member(DiscordTokenResponse response, DiscordInfoResponse userInfo) {
         this.discordToken = new DiscordToken(response.accessToken(),
                 response.refreshToken(),
@@ -65,5 +70,9 @@ public class Member {
     public void updateAuthToken(AuthTokenResponse authTokenResponse) {
         this.authToken = new AuthToken(authTokenResponse.accessToken(),
                 authTokenResponse.refreshToken());
+    }
+
+    public void setAssociationDetail(Detail detail) {
+        this.detail = detail;
     }
 }

--- a/src/main/java/com/kuit/kupage/domain/member/Member.java
+++ b/src/main/java/com/kuit/kupage/domain/member/Member.java
@@ -72,7 +72,7 @@ public class Member {
                 authTokenResponse.refreshToken());
     }
 
-    public void setAssociationDetail(Detail detail) {
+    public void updateDetail(Detail detail) {
         this.detail = detail;
     }
 }

--- a/src/main/java/com/kuit/kupage/exception/KupageException.java
+++ b/src/main/java/com/kuit/kupage/exception/KupageException.java
@@ -1,0 +1,14 @@
+package com.kuit.kupage.exception;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public class KupageException extends RuntimeException{
+
+    public KupageException(String message) {
+        super(message);
+        log.error("{} - message : {}", this.getClass().getSimpleName(), message);
+    }
+}

--- a/src/main/java/com/kuit/kupage/exception/KupageException.java
+++ b/src/main/java/com/kuit/kupage/exception/KupageException.java
@@ -7,8 +7,25 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 public class KupageException extends RuntimeException{
 
+    private static final String APP_PACKAGE_PREFIX = "com.kuit.kupage";
+
     public KupageException(String message) {
         super(message);
-        log.error("{} - message : {}", this.getClass().getSimpleName(), message);
+        StackTraceElement[] stackTrace = getStackTrace();
+
+        StringBuilder filtered = new StringBuilder();
+
+        filtered.append(this.getClass().getSimpleName())
+                .append(" - message : ")
+                .append(message)
+                .append("\n");
+
+        for (StackTraceElement element : stackTrace) {
+            if (element.getClassName().startsWith(APP_PACKAGE_PREFIX)) {
+                filtered.append("\tat ").append(element).append("\n");
+            }
+        }
+
+        log.warn(filtered.toString());
     }
 }

--- a/src/main/java/com/kuit/kupage/exception/MemberException.java
+++ b/src/main/java/com/kuit/kupage/exception/MemberException.java
@@ -1,0 +1,11 @@
+package com.kuit.kupage.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MemberException extends KupageException{
+
+    public MemberException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 구현/수정한 기능에 대해 적어주세요.")

## 이슈 번호
[KUITEE - 10](https://www.notion.so/1aefabc2141a81e7a955f7220e90b184?pvs=4)

## 개요
- 쿠이티 서비스 회원가입 만들었습니다.
- 스프링 시큐리티 기반 인증/인가 로직은 없습니다.
-  응답 방식에 대한 부분도 아직 없습니다. -> 4월5일자 백엔드 회의록에 대충 있는데 그대로 하면 될까요?
- 추가로 이후에 디스코드에서 역할 긁어오는 api 같은거 만들어줘야 완전히 끝납니다.

## 작업사항
- 회원가입
  - 'UsernamePasswordAuthenticationToken' 기반으로 한 UserDetails(AuthMember) 로 회원 식별 -> AuthMember 생성하는 로직은 아직 없지만 지금까지 개발하면서 password 필드 사용해본 적이 없는데 password 필드 없애고 getPassword()에서 null 리턴해도 되려나요?
  - 'SignupRequest' dto 기반 Detail 엔티티 생성 -> 해당 dto 밸리데이션을 제 맘대로 했는데 한번 봐주십쇼.
  - Member - Detail 간 1:1 연관관계 매핑 -> 연관관계 주인 Member 입니다. 이유 : detail 필드 null 체크로 회원가입 했는지 체크 쉽게 할 수 있음.

- 예외처리
  - 도메인별 예외는 최상위 예외로 'KupageException'을 사용하고 하위에 해당 예외를 상속 받은 도메인별 예외를 사용. ex) 'MemberException'
  - 예외가 생성될 때 log 생성됨 -> 로깅 레벨(info, warn, error) 뭘 써야할지 피드백 해주세요. 지금 보니까 error는 아닌 거 같네요.
  - 현재는 'KupageControllerAdvice' 만 사용. ExceptionHandler로 'KupageException'을 잡도록 함.

### 쿼리 발생 내역
- member 조회 1번
- Detail 생성 1번
- member - detail 연관관계 생성 1번

