### PR TITLE
[KUIT-50] 파일/이미지 업로드 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'		// swagger
+
+	// AWS
+	implementation "org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE"
 }
 
 dependencyManagement {

--- a/src/main/java/com/kuit/kupage/common/S3Service.java
+++ b/src/main/java/com/kuit/kupage/common/S3Service.java
@@ -1,0 +1,50 @@
+package com.kuit.kupage.common;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3Client s3Client;
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String bucketName;
+    @Value("${cloud.aws.cloudfront.deploy-url}")
+    private String cloudFrontUrl;
+
+    public String uploadImage(MultipartFile file) {
+        String s3FileName = "image/" + UUID.randomUUID().toString().substring(0, 10) + ".avif";
+        return uploadToS3(file, s3FileName);
+    }
+
+    public String uploadFile(MultipartFile file) {
+        String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        String s3FileName = "file/" + UUID.randomUUID().toString().substring(0, 10) + "." + extension;
+        return uploadToS3(file, s3FileName);
+    }
+
+    private String uploadToS3(MultipartFile file, String s3FileName) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getSize());
+
+        try {
+            PutObjectRequest s3Object = new PutObjectRequest(bucketName, s3FileName, file.getInputStream(), objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+            s3Client.putObject(s3Object);
+        } catch (Exception e) {
+//            throw new KupageException("파일 업로드 중 문제가 발생했습니다.");
+        }
+
+        return cloudFrontUrl + "/" + s3FileName;
+    }
+}

--- a/src/main/java/com/kuit/kupage/common/S3Service.java
+++ b/src/main/java/com/kuit/kupage/common/S3Service.java
@@ -27,7 +27,7 @@ public class S3Service {
     }
 
     public String uploadFile(MultipartFile file) {
-        String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".")+1);
         String s3FileName = "file/" + UUID.randomUUID().toString().substring(0, 10) + "." + extension;
         return uploadToS3(file, s3FileName);
     }

--- a/src/main/java/com/kuit/kupage/common/S3Service.java
+++ b/src/main/java/com/kuit/kupage/common/S3Service.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.kuit.kupage.exception.KupageException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,8 @@ public class S3Service {
     private String cloudFrontUrl;
 
     public String uploadImage(MultipartFile file) {
-        String s3FileName = "image/" + UUID.randomUUID().toString().substring(0, 10) + ".avif";
+        String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".")+1);
+        String s3FileName = "image/" + UUID.randomUUID().toString().substring(0, 10) + "." + extension;
         return uploadToS3(file, s3FileName);
     }
 
@@ -42,7 +44,7 @@ public class S3Service {
                     .withCannedAcl(CannedAccessControlList.PublicRead);
             s3Client.putObject(s3Object);
         } catch (Exception e) {
-//            throw new KupageException("파일 업로드 중 문제가 발생했습니다.");
+            throw new KupageException("파일 업로드 중 문제가 발생했습니다.");
         }
 
         return cloudFrontUrl + "/" + s3FileName;

--- a/src/main/java/com/kuit/kupage/common/config/S3Config.java
+++ b/src/main/java/com/kuit/kupage/common/config/S3Config.java
@@ -1,0 +1,30 @@
+package com.kuit.kupage.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/kuit/kupage/domain/article/UploadArticleRequest.java
+++ b/src/main/java/com/kuit/kupage/domain/article/UploadArticleRequest.java
@@ -1,0 +1,10 @@
+package com.kuit.kupage.domain.article;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UploadArticleRequest {
+    private String name;
+}

--- a/src/main/java/com/kuit/kupage/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/kuit/kupage/domain/article/controller/ArticleController.java
@@ -1,0 +1,35 @@
+package com.kuit.kupage.domain.article.controller;
+
+import com.kuit.kupage.domain.article.UploadArticleRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+
+@RestController
+@Slf4j
+public class ArticleController {
+
+    @PostMapping("/articles")
+    public void uploadArticle(
+            @RequestPart UploadArticleRequest request,
+            @RequestPart MultipartFile[] files,
+            @RequestPart MultipartFile[] imgs
+    ) {
+        log.debug("{}", request.getName());
+
+        log.debug("files.length : {}", files.length);
+        log.debug("files names : {}", Arrays.stream(files).map(MultipartFile::getOriginalFilename).toList());
+        log.debug("files size : {}", Arrays.stream(files).map(MultipartFile::getSize).toList());
+
+        log.debug("imgs length : {}", imgs.length);
+        log.debug("imgs names : {}", Arrays.stream(imgs).map(MultipartFile::getOriginalFilename).toList());
+        log.debug("imgs size : {}", Arrays.stream(imgs).map(MultipartFile::getSize).toList());
+    }
+
+
+}

--- a/src/main/java/com/kuit/kupage/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/kuit/kupage/domain/article/controller/ArticleController.java
@@ -1,6 +1,8 @@
 package com.kuit.kupage.domain.article.controller;
 
+import com.kuit.kupage.common.S3Service;
 import com.kuit.kupage.domain.article.UploadArticleRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,7 +14,10 @@ import java.util.Arrays;
 
 @RestController
 @Slf4j
+@RequiredArgsConstructor
 public class ArticleController {
+
+    private final S3Service s3Service;
 
     @PostMapping("/articles")
     public void uploadArticle(
@@ -20,6 +25,9 @@ public class ArticleController {
             @RequestPart MultipartFile[] files,
             @RequestPart MultipartFile[] imgs
     ) {
+        // files, imgs 사이즈와 개수에 대한 validation 필요
+        // servlet 선에서 각 이미지 or 파일이 20MB을 초과하거나, 모든 이미지 + 파일이 160MB(10MB x 10 + 20MB x 3)초과이면 컷
+        // 여기선 좀 더 상세하게 처리할 필요 있음
         log.debug("{}", request.getName());
 
         log.debug("files.length : {}", files.length);
@@ -29,7 +37,10 @@ public class ArticleController {
         log.debug("imgs length : {}", imgs.length);
         log.debug("imgs names : {}", Arrays.stream(imgs).map(MultipartFile::getOriginalFilename).toList());
         log.debug("imgs size : {}", Arrays.stream(imgs).map(MultipartFile::getSize).toList());
+
+        String imageUrl = s3Service.uploadImage(imgs[0]);
+        String fileUrl = s3Service.uploadFile(files[0]);
+        log.debug("imgs[0] url : {}", imageUrl);
+        log.debug("files[0] url : {}", fileUrl);
     }
-
-
 }

--- a/src/test/java/com/kuit/kupage/common/S3ServiceTest.java
+++ b/src/test/java/com/kuit/kupage/common/S3ServiceTest.java
@@ -1,0 +1,142 @@
+package com.kuit.kupage.common;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.kuit.kupage.exception.KupageException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class S3ServiceTest {
+
+    @Test
+    @DisplayName("파일 업로드 성공")
+    void test() {
+        // given
+        S3Service s3Service = new S3Service(new TestAmazonClient());
+        TestMultipartFile image = new TestMultipartFile("testImage.png", "application/png");
+        TestMultipartFile file = new TestMultipartFile("testFile.pdf", "application/pdf");
+
+        // when
+        String url1 = s3Service.uploadImage(image);
+        String url2 = s3Service.uploadFile(file);
+
+        // then
+        System.out.println("url1 = " + url1);
+        String[] url1Tokens = url1.split("/");
+        assertThat(url1Tokens[1]).isEqualTo("image");
+        assertThat(url1Tokens[2].endsWith(".png")).isEqualTo(true);
+
+        System.out.println("url1 = " + url1);
+        String[] url2Tokens = url2.split("/");
+        assertThat(url2Tokens[1]).isEqualTo("file");
+        assertThat(url2Tokens[2].endsWith(".pdf")).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("파일 업로드 실패")
+    void testFail() {
+        // given
+        S3Service s3Service = new S3Service(new TestAmazonClient());
+        TestMultipartFile image = new TestMultipartFile("testFailImage.png", "application/png");
+        TestMultipartFile file = new TestMultipartFile("testFailFile.pdf", "application/pdf");
+
+        // when
+
+        // then
+        assertThrows(KupageException.class, () -> s3Service.uploadImage(image));
+        assertThrows(KupageException.class, () -> s3Service.uploadFile(file));
+    }
+
+    static class TestAmazonClient extends AmazonS3Client {
+        @Override
+        public PutObjectResult putObject(PutObjectRequest putObjectRequest) throws SdkClientException, AmazonServiceException {
+            String key = putObjectRequest.getKey();
+            long contentLength = putObjectRequest.getMetadata().getContentLength();
+            String contentType = putObjectRequest.getMetadata().getContentType();
+            String content = "";
+            try {
+                byte[] bytes = putObjectRequest.getInputStream().readAllBytes();
+                content = new String(bytes, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            System.out.println("===== 업로드 파일 정보 =====");
+            System.out.println("key = " + key);
+            System.out.println("content = " + content);
+            System.out.println("contentLength = " + contentLength);
+            System.out.println("contentType = " + contentType);
+            System.out.println();
+
+            if (content.contains("Fail"))
+                throw new AmazonServiceException("업로드 실패");
+
+            return new PutObjectResult();
+        }
+    }
+
+    static class TestMultipartFile implements MultipartFile {
+
+        public TestMultipartFile(String data, String type) {
+            this.data = data;
+            this.type = type;
+        }
+
+        private String data;
+        private String type;
+
+        @Override
+        public String getName() {
+            return data;
+        }
+
+        @Override
+        public String getOriginalFilename() {
+            return data;
+        }
+
+        @Override
+        public String getContentType() {
+            return type;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public long getSize() {
+            return data.length();
+        }
+
+        @Override
+        public byte[] getBytes() throws IOException {
+            return data.getBytes();
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return new ByteArrayInputStream(data.getBytes());
+        }
+
+        @Override
+        public void transferTo(File dest) throws IOException, IllegalStateException {
+
+        }
+    }
+}


### PR DESCRIPTION
## 이슈 번호
[KUIT-50](https://www.notion.so/BE-1d3fabc2141a8066b943e5a73d3a717e?pvs=4)

## 개요
- Mutilpart 방식 기반으로 S3에 파일 또는 이미지를 업로드 하는 기능을 추가했습니다.

## 작업사항
- [x] Multipart 방식으로 article 등록하는 API 껍데기 작성
- [x] S3 버킷 생성 및 CloudFront 배포 연결
- [x] CloudFront 배포 경로를 자체 서브도메인으로 설정(files.kuitee.p-e.kr)
- [x] S3Service 작성(이미지, 파일 등록 기능)
- [x] 예외처리 및 테스트 작성
- [ ] 이미지 확장자, 사이즈 관련 최적화

<details>
<summary>postman 테스트</summary>
<img width="1105" alt="스크린샷 2025-04-12 01 16 42" src="https://github.com/user-attachments/assets/f493d373-7dae-461b-8292-5c544f3cf139" />
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/a8431c38-56e9-4230-894a-02e01c4340cf" />
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/0538106e-3b09-4f0d-9c43-f1eefa2c362a" />


</details>

### 쿼리 발생 내역
- 없습니다.

## 주의사항
- [application.yml 내용 갱신되었습니다.](https://www.notion.so/application-yml-1a9fabc2141a806789e0f9f3ea5c6d8c?pvs=4)
