### PR TITLE
[] blue-green 배포 및 https 적용

### DIFF
--- a/.github/workflows/Github-Action-CD.yml
+++ b/.github/workflows/Github-Action-CD.yml
@@ -59,8 +59,4 @@ jobs:
           key: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
           script: |
-            sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
-            sudo docker stop $(sudo docker ps -a -q)
-            sudo docker rm $(sudo docker ps -a -q)
-            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}
-            sudo docker run -d -p 8080:8080 --name ${{ secrets.DOCKER_CONTAINER_NAME }} ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}
+            sudo /home/ubuntu/deploy.sh


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 구현/수정한 기능에 대해 적어주세요.")

## 이슈 번호
미정

## 개요
- CI/CD 과정으로 배포 시, blue-green 전략을 적용해 무중단 배포가 가능하도록 수정했습니다.
- nginx 이용해서 https 리다이렉션 적용했습니다.

## 작업사항
- [내도메인.한국](https://xn--220b31d95hq8o.xn--3e0b707e/)에서 도메인 발급(kuitee.p-e.kr)
- EC2에 nginx 추가/인증서 발급/https 리다이렉션 적용
- CI/CD에 blue-green 배포 적용
<details>
<summary>https 리다이렉션 포스트맨 테스트</summary>
http
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/cbe5d0c8-d928-423b-91c2-dd2b8479ebbb" />
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/557c0a9d-1132-4d1e-b735-a9de5b6602cc" />
<br><br><br>
https
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/5262e6e8-f61c-473b-b180-a668904dd4ec" />
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/e95baa96-29a0-4572-88b2-c3eba26dd5b8" />
</details>

<details>
<summary>blue green 배포 적용 테스트</summary>
초기상태
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/5da74dfc-e422-4cfa-9653-33a7cb5f4084" />
<br><br><br>
<a href="https://github.com/Konkuk-KUIT/KUpage-server/actions/runs/14404334693/job/40408506841#:~:text=executing%20remote%20ssh%20commands%20using%20password">CD GitHub Action 실행</a>
<br><br><br>
이후상태
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/eb52c28a-1d2e-4dcc-afbe-59cdb16d606d" />
</details>

### 쿼리 발생 내역
- 없습니다.

## 주의사항
- 없습니다.
