### PR TITLE
Fix : swagger 문서 접근 인가 설정 및 설명 추가

### DIFF
--- a/src/main/java/com/kuit/kupage/common/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/kupage/common/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorizeRequest -> authorizeRequest
                         .requestMatchers("/oauth2/code/discord", "/", "/error",
-                                "/favicon.ico", "/v3/api-docs/**").permitAll()
+                                "/favicon.ico", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/articles").permitAll()
                 )
                 .authorizeHttpRequests(authorizeRequest -> authorizeRequest

--- a/src/main/java/com/kuit/kupage/common/file/PresignedUrlController.java
+++ b/src/main/java/com/kuit/kupage/common/file/PresignedUrlController.java
@@ -3,6 +3,8 @@ package com.kuit.kupage.common.file;
 import com.kuit.kupage.common.response.BaseResponse;
 import com.kuit.kupage.common.response.ResponseCode;
 import com.kuit.kupage.exception.ArticleException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +14,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "PresignedUrl Controller", description = "PresignedUrl 관련 Controller 입니다.")
 public class PresignedUrlController {
 
     private final PresignedUrlService presignedUrlService;
@@ -20,6 +23,7 @@ public class PresignedUrlController {
     private final static Integer MAX_FILE_SIZE = 20*1024*1024; //20MB
 
     @GetMapping("/pre-signed/articles/file")
+    @Operation(summary = "게시글 파일 업로드 링크 제공 API", description = "로그인 한 유저가 게시글을 위한 파일 업로드 링크를 제공받습니다.")
     public BaseResponse<PresignedUrlResponse> getFilePresignedUrl(@RequestBody PresignedUrlRequest request) {
         if(request.contentLength() > MAX_FILE_SIZE) {
             throw new ArticleException(ResponseCode.TOO_BIG_FILE);
@@ -31,6 +35,7 @@ public class PresignedUrlController {
     }
 
     @GetMapping("/pre-signed/articles/image")
+    @Operation(summary = "게시글 이미지 업로드 링크 제공 API", description = "로그인 한 유저가 게시글을 위한 이미지 업로드 링크를 제공받습니다.")
     public BaseResponse<PresignedUrlResponse> getImagePresignedUrl(@RequestBody PresignedUrlRequest request) {
         if(ALLOWED_IMAGE_TYPES.stream().noneMatch(t-> t.equals(request.contentType()))) {
             throw new ArticleException(ResponseCode.INVALID_IMAGE_TYPE);

--- a/src/main/java/com/kuit/kupage/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/kuit/kupage/domain/article/controller/ArticleController.java
@@ -6,6 +6,9 @@ import com.kuit.kupage.common.response.ResponseCode;
 import com.kuit.kupage.domain.article.domain.Article;
 import com.kuit.kupage.domain.article.dto.UploadArticleRequest;
 import com.kuit.kupage.domain.article.service.ArticleCreateFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,12 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
+@Tag(name = "게시글 Controller", description = "게시글 관련 Controller 입니다.")
 public class ArticleController {
 
     private final ArticleCreateFacade articleCreateFacade;
 
     @PostMapping("/articles")
-    public BaseResponse<UploadArticleResponse> uploadArticle(@Valid @RequestBody UploadArticleRequest request, @AuthenticationPrincipal AuthMember authMember) {
+    @Operation(summary = "게시글 등록 API", description = "로그인 한 유저가 게시글 등록을 요청합니다.")
+    public BaseResponse<UploadArticleResponse> uploadArticle(
+            @Valid @RequestBody UploadArticleRequest request,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
         Article article = articleCreateFacade.createArticle(request, authMember.getId());
         return new BaseResponse<>(ResponseCode.SUCCESS, new UploadArticleResponse(article.getId()));
     }

--- a/src/main/java/com/kuit/kupage/domain/detail/controller/DetailAuthController.java
+++ b/src/main/java/com/kuit/kupage/domain/detail/controller/DetailAuthController.java
@@ -5,6 +5,9 @@ import com.kuit.kupage.common.auth.AuthTokenResponse;
 import com.kuit.kupage.common.response.BaseResponse;
 import com.kuit.kupage.domain.detail.dto.SignupRequest;
 import com.kuit.kupage.domain.detail.service.DetailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,13 +21,18 @@ import static com.kuit.kupage.common.response.ResponseCode.SUCCESS;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
+@Tag(name = "유저 상세 정보 인증 Controller", description = "유저 상세 정보와 인증 관련 Controller 입니다.")
 public class DetailAuthController {
 
     private final DetailService detailService;
 
     @PostMapping("/signup")
-    public BaseResponse<AuthTokenResponse> signup(@Valid @RequestBody SignupRequest signupRequest,
-                                                    @AuthenticationPrincipal AuthMember authMember) {
+    @Operation(summary = "최종 회원가입 API", description = "유저의 상세 정보를 등록하고 회원가입을 마칩니다.")
+    public BaseResponse<AuthTokenResponse> signup(
+            @Valid @RequestBody SignupRequest signupRequest,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
 
         AuthTokenResponse response = detailService.signup(signupRequest, authMember.getId());
 

--- a/src/main/java/com/kuit/kupage/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/kuit/kupage/domain/oauth/controller/OAuthController.java
@@ -3,6 +3,8 @@ package com.kuit.kupage.domain.oauth.controller;
 import com.kuit.kupage.common.auth.TokenResponse;
 import com.kuit.kupage.common.response.BaseResponse;
 import com.kuit.kupage.domain.oauth.service.DiscordOAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,11 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/oauth2")
 @RestController
+@Tag(name = "OAuth 컨트롤러", description = "OAuth 관련 Controller 입니다.")
 public class OAuthController {
 
     private final DiscordOAuthService discordOAuthService;
 
     @GetMapping("/code/discord")
+    @Operation(summary = "디스코드 로그인/회원가입 API", description = "인가코드를 제공하고 로그인/회원가입을 진행합니다.")
     public BaseResponse<? extends TokenResponse> callback(@RequestParam("code") String code) {
         log.info("[callback] 디스코드 인가코드 발급 완료 = {}", code);
         TokenResponse response = discordOAuthService.requestToken(code);


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 구현/수정한 기능에 대해 적어주세요.")

## 이슈 번호
없음

## 개요
- 배포하고 보니 swagger 문서 접근이 안되서 SecurityConfig 수정했습니다.

## 작업사항
- SecurityConfig에서 swagger 문서 인가 설정 추가
- Controller에 Tag, Operation 설명 추가

### 쿼리 발생 내역

## 주의사항
