### PR TITLE
[KUIT-36] 1차, 2차 팀매칭 지원자 조회

### DIFF
--- a/src/main/java/com/kuit/kupage/common/response/ResponseCode.java
+++ b/src/main/java/com/kuit/kupage/common/response/ResponseCode.java
@@ -64,7 +64,8 @@ public enum ResponseCode {
     // 6000 번대 : team-match 관련
     NONE_TEAM(false, 6000, "존재하지 않는 팀입니다."), 
     NONE_OWN_TEAM(false, 6001, "소유하는 팀이 존재하지 않습니다."),
-    NONE_APPLIED_TEAM(false, 6002, "지원한 팀이 존재하지 않습니다.");
+    NONE_APPLIED_TEAM(false, 6002, "지원한 팀이 존재하지 않습니다."),
+    REJECTED_TEAM_MATCH(false, 6003, "매칭되지 않았습니다.");
 
     private boolean isSuccess;
     private int code;

--- a/src/main/java/com/kuit/kupage/domain/teamMatch/TeamApplicant.java
+++ b/src/main/java/com/kuit/kupage/domain/teamMatch/TeamApplicant.java
@@ -28,6 +28,8 @@ public class TeamApplicant extends BaseEntity {
     @Column(length = 500)
     private String portfolioUrl;
 
+    private boolean isRejected;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/kuit/kupage/domain/teamMatch/controller/TeamMatchController.java
+++ b/src/main/java/com/kuit/kupage/domain/teamMatch/controller/TeamMatchController.java
@@ -22,10 +22,6 @@ public class TeamMatchController {
 
     private final TeamMatchService teamMatchService;
 
-    // todo 결국 멤버 전체 조회 가능하도록 해야함.
-    // 운영진 -> 다 보이게
-    // PM -> 전체 및 지원 수까지 보이게
-    // 개발자, 디자이너 -> 그냥 본인이 지원한 팀 목록만
     @GetMapping("/teams/applications")
     public BaseResponse<?> applicationStatus(
             @AuthenticationPrincipal AuthMember authMember,

--- a/src/main/resources/data_init.sql
+++ b/src/main/resources/data_init.sql
@@ -150,6 +150,7 @@ INSERT INTO team_applicant (
     applied_part,
     portfolio_url,
     motivation,
+    is_rejected,
     member_id,
     team_id,
     created_at,
@@ -158,41 +159,49 @@ INSERT INTO team_applicant (
       (1, 'Android',
        'https://github.com/jwkim/Android-portfolio',
        'Android Studio로 앱을 개발한 경험이 있습니다.',
+       false,
        2, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655'),
 
       (2, 'Android',
        'https://github.com/hwlee/Android-toy',
        'Kotlin과 Firebase를 활용한 프로젝트 경험이 있습니다.',
+       false,
        3, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655'),
 
       (3, 'iOS',
        'https://github.com/sylee/ios-portfolio',
        'UIKit, SwiftUI 모두 사용해봤습니다.',
+       false,
        4, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655'),
 
       (4, 'Web',
        'https://github.com/mspark/web-portfolio',
        'React와 Next.js 기반 프로젝트 경험이 있습니다.',
+       false,
        5, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655'),
 
       (5, 'Web',
        'https://github.com/yjjeong/web-demo',
        'TypeScript와 Zustand를 이용한 상태 관리 경험이 있습니다.',
+       false,
        6, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655'),
 
       (6, 'Server',
        'https://github.com/haeun/server-portfolio',
        'Spring Boot, JPA 기반 REST API 개발 경험이 있습니다.',
+       false,
        7, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655'),
 
       (7, 'Design',
        'https://behance.net/mjchoi-design',
        'Figma와 Adobe XD를 활용한 UI/UX 디자인 경험이 있습니다.',
+       false,
        8, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655'),
 
       (8, 'Design',
        'https://dribbble.com/sbhan',
        '브랜딩과 인터랙션 디자인 프로젝트를 진행했습니다.',
+       false,
        9, 1, '2025-11-02 22:40:50.709655', '2025-11-02 22:40:50.709655');
 
 SELECT * FROM MEMBER;


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 구현/수정한 기능에 대해 적어주세요.")

## 이슈 번호
Close #36 

## 개요
- 1차, 2차 매칭 시 탈락한 지원자 정보가 조회되지 않도록 설정

## 작업사항
- TeamApplicant 테이블 is_rejected 컬럼 추가 - 기본 false
- PM이 탈락 결정 시 해당 엔티티의 is_rejected 컬럼 true로 변경
- 내부 로직에서 해당 값을 기준으로 조회 여부 결정

### 쿼리 발생 내역
- 기존과 동일

## 주의사항
- 엔티티 스펙에 변화 -> 머지 이후 erd 반영 예정

